### PR TITLE
fix off-by-one error in input buffer length

### DIFF
--- a/R/parse-multipart.R
+++ b/R/parse-multipart.R
@@ -17,7 +17,7 @@ parse.multipart <- function(request = .GlobalEnv$request) {
   # so this is to emulate that API
   body.pos <- 1L
   input <- list(rewind=function() body.pos <<- 1L,
-                read=function(n) { if (body.pos >= length(body)) return(raw()); v <- body[seq.int(body.pos, body.pos + n)]; body.pos <<- body.pos + n; v })
+                read=function(n) { if (body.pos >= length(body)) return(raw()); v <- body[seq.int(body.pos, body.pos + n)]; body.pos <<- body.pos + n + 1; v })
   
   ## return value
   params  <- list()


### PR DESCRIPTION
I believe the calculation for setting the next input position is off by one. This should fix it. If you like I can email you separately a Request object which I have that was throwing an error on parse.multiple(request), but which works with this modification.