### PR TITLE
use mkdir -p because directory exists on repeated builds

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -7,7 +7,7 @@ all:
 	@(cd Rcgi && $(MAKE))
 	rm -rf $(INST)/Rcgi
 	cp -r Rcgi $(INST)
-	mkdir $(CGIBIN)
+	mkdir -p $(CGIBIN)
 	@(if test -e Rcgi/Rcgi; then cp Rcgi/Rcgi $(CGIBIN)/; fi)
 	@(if test -e Rcgi/Rcgi.exe; then cp Rcgi/Rcgi.exe $(CGIBIN)/; fi)
 	touch null.so null.dll # to make R CMD SHLIB happy


### PR DESCRIPTION
This minor change adds `-p` to the `mkdir` command so it does not fail if the directory already exists. I ran into this when attempting repeated builds using R CMD INSTALL on an extracted directory containing the release version of FastRWeb. This change corrects the problem.

I've tested that `mkdir -p` works in PowerShell and CMD on whatever version of Windows 11 I am running, in case that's a concern. I wasn't sure if this script was meant to be cross platform.